### PR TITLE
add DeepCache to accelerate denoising loop

### DIFF
--- a/latentsync/pipelines/lipsync_pipeline.py
+++ b/latentsync/pipelines/lipsync_pipeline.py
@@ -46,7 +46,7 @@ class LipsyncPipeline(DiffusionPipeline):
         self,
         vae: AutoencoderKL,
         audio_encoder: Audio2Feature,
-        denoising_unet: UNet3DConditionModel,
+        unet: UNet3DConditionModel,
         scheduler: Union[
             DDIMScheduler,
             PNDMScheduler,
@@ -85,11 +85,11 @@ class LipsyncPipeline(DiffusionPipeline):
             new_config["clip_sample"] = False
             scheduler._internal_dict = FrozenDict(new_config)
 
-        is_unet_version_less_0_9_0 = hasattr(denoising_unet.config, "_diffusers_version") and version.parse(
-            version.parse(denoising_unet.config._diffusers_version).base_version
+        is_unet_version_less_0_9_0 = hasattr(unet.config, "_diffusers_version") and version.parse(
+            version.parse(unet.config._diffusers_version).base_version
         ) < version.parse("0.9.0.dev0")
         is_unet_sample_size_less_64 = (
-            hasattr(denoising_unet.config, "sample_size") and denoising_unet.config.sample_size < 64
+            hasattr(unet.config, "sample_size") and unet.config.sample_size < 64
         )
         if is_unet_version_less_0_9_0 and is_unet_sample_size_less_64:
             deprecation_message = (
@@ -104,14 +104,14 @@ class LipsyncPipeline(DiffusionPipeline):
                 " the `unet/config.json` file"
             )
             deprecate("sample_size<64", "1.0.0", deprecation_message, standard_warn=False)
-            new_config = dict(denoising_unet.config)
+            new_config = dict(unet.config)
             new_config["sample_size"] = 64
-            denoising_unet._internal_dict = FrozenDict(new_config)
+            unet._internal_dict = FrozenDict(new_config)
 
         self.register_modules(
             vae=vae,
             audio_encoder=audio_encoder,
-            denoising_unet=denoising_unet,
+            unet=unet,
             scheduler=scheduler,
         )
 
@@ -127,9 +127,9 @@ class LipsyncPipeline(DiffusionPipeline):
 
     @property
     def _execution_device(self):
-        if self.device != torch.device("meta") or not hasattr(self.denoising_unet, "_hf_hook"):
+        if self.device != torch.device("meta") or not hasattr(self.unet, "_hf_hook"):
             return self.device
-        for module in self.denoising_unet.modules():
+        for module in self.unet.modules():
             if (
                 hasattr(module, "_hf_hook")
                 and hasattr(module._hf_hook, "execution_device")
@@ -334,8 +334,8 @@ class LipsyncPipeline(DiffusionPipeline):
         callback_steps: Optional[int] = 1,
         **kwargs,
     ):
-        is_train = self.denoising_unet.training
-        self.denoising_unet.eval()
+        is_train = self.unet.training
+        self.unet.eval()
 
         check_ffmpeg_installed()
 
@@ -347,8 +347,8 @@ class LipsyncPipeline(DiffusionPipeline):
         self.set_progress_bar_config(desc=f"Sample frames: {num_frames}")
 
         # 1. Default height and width to unet
-        height = height or self.denoising_unet.config.sample_size * self.vae_scale_factor
-        width = width or self.denoising_unet.config.sample_size * self.vae_scale_factor
+        height = height or self.unet.config.sample_size * self.vae_scale_factor
+        width = width or self.unet.config.sample_size * self.vae_scale_factor
 
         # 2. Check inputs
         self.check_inputs(height, width, callback_steps)
@@ -391,7 +391,7 @@ class LipsyncPipeline(DiffusionPipeline):
 
         num_inferences = math.ceil(len(whisper_chunks) / num_frames)
         for i in tqdm.tqdm(range(num_inferences), desc="Doing inference..."):
-            if self.denoising_unet.add_audio_layer:
+            if self.unet.add_audio_layer:
                 audio_embeds = torch.stack(whisper_chunks[i * num_frames : (i + 1) * num_frames])
                 audio_embeds = audio_embeds.to(device, dtype=weight_dtype)
                 if do_classifier_free_guidance:
@@ -431,18 +431,18 @@ class LipsyncPipeline(DiffusionPipeline):
             with self.progress_bar(total=num_inference_steps) as progress_bar:
                 for j, t in enumerate(timesteps):
                     # expand the latents if we are doing classifier free guidance
-                    denoising_unet_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+                    unet_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
 
-                    denoising_unet_input = self.scheduler.scale_model_input(denoising_unet_input, t)
+                    unet_input = self.scheduler.scale_model_input(unet_input, t)
 
                     # concat latents, mask, masked_image_latents in the channel dimension
-                    denoising_unet_input = torch.cat(
-                        [denoising_unet_input, mask_latents, masked_image_latents, ref_latents], dim=1
+                    unet_input = torch.cat(
+                        [unet_input, mask_latents, masked_image_latents, ref_latents], dim=1
                     )
 
                     # predict the noise residual
-                    noise_pred = self.denoising_unet(
-                        denoising_unet_input, t, encoder_hidden_states=audio_embeds
+                    noise_pred = self.unet(
+                        unet_input, t, encoder_hidden_states=audio_embeds
                     ).sample
 
                     # perform guidance
@@ -472,7 +472,7 @@ class LipsyncPipeline(DiffusionPipeline):
         audio_samples = audio_samples[:audio_samples_remain_length].cpu().numpy()
 
         if is_train:
-            self.denoising_unet.train()
+            self.unet.train()
 
         temp_dir = "temp"
         if os.path.exists(temp_dir):

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ numpy==1.26.4
 kornia==0.8.0
 insightface==0.7.3
 onnxruntime-gpu==1.21.0
+DeepCache==0.1.1

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -21,6 +21,7 @@ from latentsync.models.unet import UNet3DConditionModel
 from latentsync.pipelines.lipsync_pipeline import LipsyncPipeline
 from accelerate.utils import set_seed
 from latentsync.whisper.audio2feature import Audio2Feature
+from DeepCache import DeepCacheSDHelper
 
 
 def main(config, args):
@@ -68,9 +69,17 @@ def main(config, args):
     pipeline = LipsyncPipeline(
         vae=vae,
         audio_encoder=audio_encoder,
-        denoising_unet=denoising_unet,
+        unet=denoising_unet,
         scheduler=scheduler,
     ).to("cuda")
+
+    # use DeepCache
+    helper = DeepCacheSDHelper(pipe=pipeline)
+    helper.set_params(
+        cache_interval=3,
+        cache_branch_id=0,
+    )
+    helper.enable()
 
     if args.seed != -1:
         set_seed(args.seed)


### PR DESCRIPTION
通过将 ./scripts/inference.py 中， helper 的 cache_interval 和 cache_branch_id 设置为不同数值，可以对质量与速度产生不同的影响。两个参数的值越小，速度越快，质量越低。
并且，推理速度的提升效果与 inference_steps 有关，步数越多，提升效果越显著。在默认参数下，4090的推理速度可以由10it/s左右提升到20it/s左右。
目前DeepCache的启用，以及两个参数的值是写死的，也许还有更合适的写法？请各位指教，感谢！