### PR TITLE
Add Configurable Gradio Launch Settings with Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ wandb/
 !/docs/*
 !/internal/*.png
 .cog/
+config.yaml

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -1,0 +1,6 @@
+server_name: "0.0.0.0"
+server_port: 8080
+public_share: true
+auth:
+  - "admin"
+  - "password"

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -6,7 +6,10 @@ import argparse
 from datetime import datetime
 
 CONFIG_PATH = Path("configs/unet/stage2_512.yaml")
+GRADIO_CONFIG = Path("config.yaml")
 CHECKPOINT_PATH = Path("checkpoints/latentsync_unet.pt")
+
+gradio_config = OmegaConf.load(GRADIO_CONFIG)
 
 
 def process_video(
@@ -152,4 +155,10 @@ with gr.Blocks(title="LatentSync demo") as demo:
     )
 
 if __name__ == "__main__":
-    demo.launch(inbrowser=True, share=True)
+    demo.launch(
+    inbrowser=True,
+    share=gradio_config.public_share,
+    server_name=gradio_config.server_name,
+    server_port=gradio_config.server_port,
+    auth=tuple(gradio_config.auth)
+    )


### PR DESCRIPTION
## Description
This PR updates the Gradio app launch process to use a centralized configuration file (`config.yaml`) for runtime parameters and adds basic authentication support to protect the interface.

### Changes Included
- Integrated **`config.yaml`** to store and manage Gradio launch parameters:
  - `public_share` → Controls whether a public shareable link is created
  - `server_name` → Hostname or IP address the app will bind to
  - `server_port` → Port number for the Gradio server
  - `auth` → Username/password tuple for interface authentication
- Updated `demo.launch()` call to dynamically use configuration values.